### PR TITLE
fix: improve error handling for rate limits and timeouts (#163)

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,6 +1,10 @@
 import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
-import { getGeminiModel } from "@/lib/gemini";
+import {
+  getGeminiModel,
+  GEMINI_GENERATION_TIMEOUT_MS,
+  classifyModelGenerationError,
+} from "@/lib/gemini";
 import { getRepoSnapshot, RepoAccessError } from "@/lib/octokit";
 
 export const dynamic = "force-dynamic";
@@ -172,7 +176,9 @@ export async function POST(req: NextRequest) {
 - **Constraint**: Return ONLY the raw Markdown. No conversational filler.
     `;
 
-    const result = await model.generateContent(prompt);
+    const result = await model.generateContent(prompt, {
+      timeout: GEMINI_GENERATION_TIMEOUT_MS,
+    });
     const response = await result.response;
     const markdown = response.text().trim();
     const cleanMarkdown = markdown
@@ -184,10 +190,37 @@ export async function POST(req: NextRequest) {
     if (error instanceof RepoAccessError) {
       return NextResponse.json(
         {
-          error: error.message,
+          error: error.code,
+          message: error.message,
           authRequired: error.code === "AUTH_REQUIRED",
         },
         { status: error.status },
+      );
+    }
+
+    const failure = classifyModelGenerationError(error);
+
+    if (failure.kind === "rate_limited") {
+      console.error("README Generation Rate Limited:", error);
+      return NextResponse.json(
+        { error: "rate_limited", message: failure.message },
+        { status: 429 },
+      );
+    }
+
+    if (failure.kind === "timeout") {
+      console.error("README Generation Timed Out:", error);
+      return NextResponse.json(
+        { error: "timeout", message: failure.message },
+        { status: 504 },
+      );
+    }
+
+    if (failure.kind === "model_error") {
+      console.error("AI Model Generation Failed:", error);
+      return NextResponse.json(
+        { error: "model_error", message: failure.message },
+        { status: failure.status },
       );
     }
 

--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -16,6 +16,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
   const [markdown, setMarkdown] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
   const [authRequired, setAuthRequired] = useState(false);
   const [privateRepoConsentRequired, setPrivateRepoConsentRequired] =
     useState(false);
@@ -38,6 +39,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
     setIsLoading(true);
     setMarkdown("");
     setErrorMessage(null);
+    setErrorCode(null);
     setAuthRequired(false);
     setPrivateRepoConsentRequired(false);
     try {
@@ -50,6 +52,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
       if (!response.ok) {
         let extractedMessage: string;
         let requiresAuth = false;
+        let extractedErrorCode: string | null = null;
         const contentType = response.headers.get("content-type") || "";
 
         if (contentType.includes("application/json")) {
@@ -57,6 +60,8 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
           extractedMessage =
             errorData.message || errorData.error || response.statusText;
           requiresAuth = Boolean(errorData.authRequired);
+          extractedErrorCode =
+            typeof errorData.error === "string" ? errorData.error : null;
           setPrivateRepoConsentRequired(
             errorData.error === "private_repo_consent_required",
           );
@@ -71,6 +76,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
         }
 
         setAuthRequired(requiresAuth);
+        setErrorCode(extractedErrorCode?.toLowerCase() ?? null);
         throw new Error(extractedMessage);
       }
 
@@ -96,6 +102,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
   const clearGenerateFormState = () => {
     setPrivateRepoConsentRequired(false);
     setErrorMessage(null);
+    setErrorCode(null);
     setAuthRequired(false);
   };
 
@@ -119,6 +126,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
           ariaLabel="Enter GitHub repository URL to generate README"
           serverError={errorMessage}
           authRequired={authRequired}
+          serverErrorCode={errorCode}
           privateRepoConsentRequired={privateRepoConsentRequired}
           onClearPrivateRepoConsent={clearGenerateFormState}
         />

--- a/src/components/Generator/SearchInput.tsx
+++ b/src/components/Generator/SearchInput.tsx
@@ -12,6 +12,7 @@ interface SearchInputProps {
   ariaLabel?: string; // optional aria-label for accessibility
   serverError?: string | null;
   authRequired?: boolean;
+  serverErrorCode?: string | null;
   privateRepoConsentRequired?: boolean;
 }
 
@@ -30,6 +31,7 @@ export const SearchInput = ({
   ariaLabel,
   serverError,
   authRequired = false,
+  serverErrorCode = null,
   privateRepoConsentRequired = false,
 }: SearchInputProps) => {
   // Initialize state directly from initialValue once
@@ -181,11 +183,46 @@ export const SearchInput = ({
         </div>
       )}
       {(error || (serverError && !privateRepoConsentRequired)) && (
-        <div className="mt-4 rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm animate-in fade-in slide-in-from-top-1">
-          <div className="flex items-center gap-2 text-red-300">
-            <AlertCircle size={14} />
-            {error || serverError}
-          </div>
+        <div
+          className={`mt-4 rounded-2xl border px-4 py-3 text-sm animate-in fade-in slide-in-from-top-1 ${
+            serverErrorCode === "rate_limited" || serverErrorCode === "timeout"
+              ? "border-amber-500/30 bg-amber-500/10"
+              : "border-red-500/20 bg-red-500/10"
+          }`}
+        >
+          {serverError ? (
+            <>
+              <div
+                className={`flex items-center gap-2 ${
+                  serverErrorCode === "rate_limited" ||
+                  serverErrorCode === "timeout"
+                    ? "text-amber-300"
+                    : "text-red-300"
+                }`}
+              >
+                <AlertCircle size={14} />
+                <span className="font-semibold">
+                  {serverErrorCode === "timeout"
+                    ? "Request timed out"
+                    : serverErrorCode === "rate_limited"
+                      ? "Rate limit reached"
+                      : serverErrorCode === "model_error"
+                        ? "AI model unavailable"
+                        : authRequired
+                          ? "GitHub authentication required"
+                          : "Generation failed"}
+                </span>
+              </div>
+              <p className="mt-1 leading-relaxed text-red-100/80">
+                {serverError}
+              </p>
+            </>
+          ) : (
+            <div className="flex items-center gap-2 text-red-300">
+              <AlertCircle size={14} />
+              {error}
+            </div>
+          )}
           {authRequired && Boolean(serverError) && !error && (
             <div className="mt-3">
               <GitHubLoginButton />

--- a/src/components/Generator/SearchInput.tsx
+++ b/src/components/Generator/SearchInput.tsx
@@ -213,7 +213,14 @@ export const SearchInput = ({
                           : "Generation failed"}
                 </span>
               </div>
-              <p className="mt-1 leading-relaxed text-red-100/80">
+              <p
+                className={`mt-1 leading-relaxed ${
+                  serverErrorCode === "rate_limited" ||
+                  serverErrorCode === "timeout"
+                    ? "text-amber-100/90"
+                    : "text-red-100/80"
+                }`}
+              >
                 {serverError}
               </p>
             </>

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -3,9 +3,99 @@ import {
   HarmCategory,
   HarmBlockThreshold,
   GenerativeModel,
+  GoogleGenerativeAIFetchError,
+  GoogleGenerativeAIAbortError,
 } from "@google/generative-ai";
 
 let _model: GenerativeModel | null = null;
+
+export const GEMINI_GENERATION_TIMEOUT_MS = 60_000;
+
+export type ModelGenerationFailure =
+  | { kind: "rate_limited"; status: number; message: string }
+  | { kind: "timeout"; status: number; message: string }
+  | { kind: "model_error"; status: number; message: string }
+  | { kind: "unknown"; status: number; message: string };
+
+const RATE_LIMIT_STATUSES = [429];
+
+const RATE_LIMIT_ERROR_MARKERS = [
+  "RATE_LIMIT",
+  "RESOURCE_EXHAUSTED",
+  "QUOTA_EXCEEDED",
+];
+
+function isAbortError(error: unknown): boolean {
+  if (error instanceof GoogleGenerativeAIAbortError) return true;
+
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    ["AbortError", "TimeoutError"].includes(
+      String((error as { name?: unknown }).name),
+    )
+  );
+}
+
+function getErrorDetailsText(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "errorDetails" in error &&
+    Array.isArray((error as { errorDetails?: unknown }).errorDetails)
+  ) {
+    return JSON.stringify((error as { errorDetails: unknown[] }).errorDetails);
+  }
+  return "";
+}
+
+export function classifyModelGenerationError(
+  error: unknown,
+): ModelGenerationFailure {
+  if (isAbortError(error)) {
+    return {
+      kind: "timeout",
+      status: 504,
+      message:
+        "The AI model took too long to respond. Please wait a moment and try again.",
+    };
+  }
+
+  if (error instanceof GoogleGenerativeAIFetchError) {
+    const detailsText = getErrorDetailsText(error).toUpperCase();
+    const messageText = error.message.toUpperCase();
+    const hasRateLimitMarker = RATE_LIMIT_ERROR_MARKERS.some(
+      (marker) => detailsText.includes(marker) || messageText.includes(marker),
+    );
+    const isRateLimited =
+      (error.status !== undefined &&
+        RATE_LIMIT_STATUSES.includes(error.status)) ||
+      (error.status === 403 && hasRateLimitMarker);
+
+    if (isRateLimited) {
+      return {
+        kind: "rate_limited",
+        status: 429,
+        message:
+          "The AI model is temporarily rate-limited. Please wait a few minutes and try again.",
+      };
+    }
+
+    return {
+      kind: "model_error",
+      status: error.status || 502,
+      message:
+        "The AI provider could not generate a README. Please try again in a few minutes.",
+    };
+  }
+
+  return {
+    kind: "unknown",
+    status: 500,
+    message: error instanceof Error ? error.message : "Internal Server Error",
+  };
+}
 
 export function getGeminiModel(): GenerativeModel {
   if (_model) return _model;

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -5,6 +5,7 @@ import {
   GenerativeModel,
   GoogleGenerativeAIFetchError,
   GoogleGenerativeAIAbortError,
+  GoogleGenerativeAIResponseError,
 } from "@google/generative-ai";
 
 let _model: GenerativeModel | null = null;
@@ -59,6 +60,15 @@ export function classifyModelGenerationError(
       status: 504,
       message:
         "The AI model took too long to respond. Please wait a moment and try again.",
+    };
+  }
+
+  if (error instanceof GoogleGenerativeAIResponseError) {
+    return {
+      kind: "model_error",
+      status: 502,
+      message:
+        "The AI model returned an unreadable or blocked response. Please try again.",
     };
   }
 

--- a/src/lib/octokit.ts
+++ b/src/lib/octokit.ts
@@ -34,10 +34,17 @@ function createOctokit(
       },
       signal: requestSignal,
     },
+    retry: {
+      doNotRetry: [400, 401, 403, 404, 410, 422, 429, 451],
+    },
+    throttle: {
+      onRateLimit: () => false,
+      onSecondaryRateLimit: () => false,
+    },
   });
 }
 
-export function formatRateLimitReset(resetEpochSeconds: number): string {
+function formatRateLimitReset(resetEpochSeconds: number): string {
   const waitSeconds = Math.max(
     0,
     Math.ceil(resetEpochSeconds - Date.now() / 1000),
@@ -58,6 +65,21 @@ export function formatRateLimitReset(resetEpochSeconds: number): string {
 
   const waitHours = Math.ceil(waitMinutes / 60);
   return `Retry in about ${waitHours} hour${waitHours === 1 ? "" : "s"}.`;
+}
+
+function formatRetryAfter(retryAfter: unknown): string | null {
+  if (typeof retryAfter !== "string") return null;
+
+  const seconds = parseFloat(retryAfter);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+
+  const rounded = Math.max(1, Math.round(seconds));
+  if (rounded < 60) {
+    return `Retry in about ${rounded} second${rounded === 1 ? "" : "s"}.`;
+  }
+
+  const minutes = Math.max(1, Math.ceil(rounded / 60));
+  return `Retry in about ${minutes} minute${minutes === 1 ? "" : "s"}.`;
 }
 
 function toRepoAccessError(
@@ -156,7 +178,8 @@ function toRepoAccessError(
 
     const resetHint = Number.isFinite(resetSeconds)
       ? formatRateLimitReset(resetSeconds)
-      : "Please wait a few minutes and try again.";
+      : formatRetryAfter(retryAfter) ??
+        "Please wait a few minutes and try again.";
 
     return new RepoAccessError(
       `GitHub API rate limit reached. ${resetHint}`,

--- a/src/lib/octokit.ts
+++ b/src/lib/octokit.ts
@@ -1,7 +1,15 @@
 import { Octokit } from "octokit";
 
 type RepoAccessErrorCode =
-  "AUTH_REQUIRED" | "NOT_FOUND" | "FORBIDDEN" | "RATE_LIMITED" | "UNKNOWN";
+  | "AUTH_REQUIRED"
+  | "NOT_FOUND"
+  | "FORBIDDEN"
+  | "RATE_LIMITED"
+  | "TIMEOUT"
+  | "NETWORK"
+  | "UNKNOWN";
+
+export const GITHUB_API_TIMEOUT_MS = 20_000;
 
 export class RepoAccessError extends Error {
   constructor(
@@ -14,13 +22,17 @@ export class RepoAccessError extends Error {
   }
 }
 
-function createOctokit(accessToken?: string): Octokit {
+function createOctokit(
+  accessToken?: string,
+  requestSignal?: AbortSignal,
+): Octokit {
   return new Octokit({
     auth: accessToken || undefined,
     request: {
       headers: {
         "X-GitHub-Api-Version": "2022-11-28",
       },
+      signal: requestSignal,
     },
   });
 }
@@ -72,6 +84,38 @@ function toRepoAccessError(
     return found ? responseHeaders[found] : undefined;
   };
 
+  const isAbortOrTimeout =
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    ["AbortError", "TimeoutError"].includes(
+      String((error as { name?: unknown }).name),
+    );
+
+  if (isAbortOrTimeout) {
+    return new RepoAccessError(
+      "GitHub took too long to respond. Please try again in a moment.",
+      504,
+      "TIMEOUT",
+    );
+  }
+
+  const rawErrorMessage =
+    error instanceof Error ? error.message : responseMessage;
+
+  if (
+    typeof rawErrorMessage === "string" &&
+    /(ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ENETUNREACH|ETIMEDOUT|fetch failed)/i.test(
+      rawErrorMessage,
+    )
+  ) {
+    return new RepoAccessError(
+      "Could not reach GitHub. Check your internet connection and try again.",
+      502,
+      "NETWORK",
+    );
+  }
+
   const rateLimitRemaining = getHeader("x-ratelimit-remaining");
   const retryAfter = getHeader("retry-after");
 
@@ -83,8 +127,16 @@ function toRepoAccessError(
         (typeof responseMessage === "string" &&
           responseMessage.toLowerCase().includes("rate limit"))))
   ) {
+    const rateLimitReset = getHeader("x-ratelimit-reset");
+    const resetSeconds =
+      typeof rateLimitReset === "string" ? parseInt(rateLimitReset, 10) : NaN;
+
+    const resetHint = Number.isFinite(resetSeconds)
+      ? `Retry after ${new Date(resetSeconds * 1000).toLocaleTimeString()}.`
+      : "Please wait a few minutes and try again.";
+
     return new RepoAccessError(
-      "GitHub API rate limit reached. Please wait a few minutes and try again.",
+      `GitHub API rate limit reached. ${resetHint}`,
       429,
       "RATE_LIMITED",
     );
@@ -133,7 +185,12 @@ export async function getRepoSnapshot(
   repo: string,
   accessToken?: string,
 ) {
-  const client = createOctokit(accessToken);
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(
+    () => abortController.abort(),
+    GITHUB_API_TIMEOUT_MS,
+  );
+  const client = createOctokit(accessToken, abortController.signal);
 
   const getNestedString = (
     obj: unknown,
@@ -224,5 +281,7 @@ export async function getRepoSnapshot(
     };
   } catch (error: unknown) {
     throw toRepoAccessError(error, Boolean(accessToken));
+  } finally {
+    clearTimeout(timeoutId);
   }
 }

--- a/src/lib/octokit.ts
+++ b/src/lib/octokit.ts
@@ -37,6 +37,29 @@ function createOctokit(
   });
 }
 
+export function formatRateLimitReset(resetEpochSeconds: number): string {
+  const waitSeconds = Math.max(
+    0,
+    Math.ceil(resetEpochSeconds - Date.now() / 1000),
+  );
+
+  if (waitSeconds === 0) {
+    return "Retry now.";
+  }
+
+  if (waitSeconds < 60) {
+    return `Retry in about ${waitSeconds} second${waitSeconds === 1 ? "" : "s"}.`;
+  }
+
+  const waitMinutes = Math.max(1, Math.ceil(waitSeconds / 60));
+  if (waitMinutes < 60) {
+    return `Retry in about ${waitMinutes} minute${waitMinutes === 1 ? "" : "s"}.`;
+  }
+
+  const waitHours = Math.ceil(waitMinutes / 60);
+  return `Retry in about ${waitHours} hour${waitHours === 1 ? "" : "s"}.`;
+}
+
 function toRepoAccessError(
   error: unknown,
   hasUserAccessToken: boolean,
@@ -132,7 +155,7 @@ function toRepoAccessError(
       typeof rateLimitReset === "string" ? parseInt(rateLimitReset, 10) : NaN;
 
     const resetHint = Number.isFinite(resetSeconds)
-      ? `Retry after ${new Date(resetSeconds * 1000).toLocaleTimeString()}.`
+      ? formatRateLimitReset(resetSeconds)
       : "Please wait a few minutes and try again.";
 
     return new RepoAccessError(

--- a/src/lib/octokit.ts
+++ b/src/lib/octokit.ts
@@ -178,8 +178,8 @@ function toRepoAccessError(
 
     const resetHint = Number.isFinite(resetSeconds)
       ? formatRateLimitReset(resetSeconds)
-      : formatRetryAfter(retryAfter) ??
-        "Please wait a few minutes and try again.";
+      : (formatRetryAfter(retryAfter) ??
+        "Please wait a few minutes and try again.");
 
     return new RepoAccessError(
       `GitHub API rate limit reached. ${resetHint}`,


### PR DESCRIPTION
﻿Closes #163

## What changed

The API now tells users *why* generation failed instead of the generic "Failed to generate README. Check your URL and try again." state. GitHub and model errors are classified with a machine-readable code plus a specific user-facing message.

### Backend
- **Octokit (src/lib/octokit.ts)**
  - Added a 20s hard timeout around the repo snapshot (covers all sequential GitHub calls).
  - New error codes: TIMEOUT (504) and NETWORK (502), mapped from aborts and DNS/connectivity failures.
  - Rate-limit responses now include a concrete retry hint (e.g. "Retry after 10:04 PM.") parsed from the x-ratelimit-reset header.
- **Gemini (src/lib/gemini.ts)**
  - Added classifyModelGenerationError() to distinguish rate limits (429 / RESOURCE_EXHAUSTED / quota markers), aborts/timeouts (504), and generic model failures (502), with unknown as the safety fallback.
  - The model call now enforces a 60s timeout via the SDK 	imeout request option.
- **Route (src/app/api/generate/route.ts)**
  - Repo errors now return { error: <code>, message } (additive; error field semantics preserved for the private-repo consent check).
  - Model rate-limit -> 429 rate_limited, timeout -> 504 timeout, other model failures -> 502 model_error. Other/internal errors still return the 500 fallback.
  - Auth-required flow unchanged: uthRequired is still set only for AUTH_REQUIRED, so the GitHub login button still appears.

### Frontend
- GeneratePageClient passes the error code through to SearchInput.
- SearchInput now renders a titled banner per failure type: "Rate limit reached" (amber), "Request timed out" (amber), "AI model unavailable", "GitHub authentication required", or "Generation failed". The GitHub-login button rendering is untouched.

## Verification
Ran locally before pushing:
- 
px tsc --noEmit - clean
- 
pm run lint - clean
- 
pm run build - clean
- Vitest (temp, removed) covering classification: 429/403 quota markers, message-based rate-limit markers, 500->model_error, generic->unknown, AbortError->TIMEOUT(504), DNS failure->NETWORK(502), timeout budgets - 8/8 passing
