### PR TITLE
feat: save recent generations in local history

### DIFF
--- a/src/__tmp__/generationHistory.test.ts
+++ b/src/__tmp__/generationHistory.test.ts
@@ -32,7 +32,11 @@ function createFakeStorage(initial?: Record<string, string>): FakeStorage {
   };
 }
 
-function makeEntry(url: string, language = "English", markdown = "# Readme"): GenerationHistoryEntry {
+function makeEntry(
+  url: string,
+  language = "English",
+  markdown = "# Readme",
+): GenerationHistoryEntry {
   return {
     id: `id-${url}-${language}`,
     url,
@@ -44,7 +48,12 @@ function makeEntry(url: string, language = "English", markdown = "# Readme"): Ge
 
 describe("appendGeneration", () => {
   it("adds a new entry at the front and normalizes the URL", () => {
-    const next = appendGeneration([], "  https://github.com/Owner/Repo/ ", "English", "# Hi");
+    const next = appendGeneration(
+      [],
+      "  https://github.com/Owner/Repo/ ",
+      "English",
+      "# Hi",
+    );
     expect(next).toHaveLength(1);
     expect(next[0].url).toBe("https://github.com/Owner/Repo");
     expect(next[0].language).toBe("English");
@@ -55,7 +64,13 @@ describe("appendGeneration", () => {
     const first = [makeEntry("https://github.com/a/b", "English")];
     const oldDate = 100;
     const firstWithDate = [{ ...first[0], createdAt: oldDate }];
-    const next = appendGeneration(firstWithDate, "https://github.com/A/B", "English", "# v2", 500);
+    const next = appendGeneration(
+      firstWithDate,
+      "https://github.com/A/B",
+      "English",
+      "# v2",
+      500,
+    );
     expect(next).toHaveLength(1);
     expect(next[0].markdown).toBe("# v2");
     expect(next[0].createdAt).toBe(500);
@@ -74,15 +89,27 @@ describe("appendGeneration", () => {
   it("evicts the oldest entries beyond the maximum", () => {
     let entries: GenerationHistoryEntry[] = [];
     for (let i = 0; i < MAX_HISTORY_ENTRIES + 5; i++) {
-      entries = appendGeneration(entries, `https://github.com/owner/repo${i}`, "English", "# x");
+      entries = appendGeneration(
+        entries,
+        `https://github.com/owner/repo${i}`,
+        "English",
+        "# x",
+      );
     }
     expect(entries).toHaveLength(MAX_HISTORY_ENTRIES);
-    expect(entries[0].url).toBe(`https://github.com/owner/repo${MAX_HISTORY_ENTRIES + 4}`);
+    expect(entries[0].url).toBe(
+      `https://github.com/owner/repo${MAX_HISTORY_ENTRIES + 4}`,
+    );
   });
 
   it("truncates oversized markdown", () => {
     const hugeMarkdown = "x".repeat(MAX_MARKDOWN_CHARS + 500);
-    const next = appendGeneration([], "https://github.com/a/b", "English", hugeMarkdown);
+    const next = appendGeneration(
+      [],
+      "https://github.com/a/b",
+      "English",
+      hugeMarkdown,
+    );
     expect(next[0].markdown.length).toBe(MAX_MARKDOWN_CHARS);
   });
 });
@@ -93,12 +120,16 @@ describe("loadHistory", () => {
   });
 
   it("returns [] for corrupt JSON", () => {
-    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: "{not json" });
+    const storage = createFakeStorage({
+      [GENERATION_HISTORY_KEY]: "{not json",
+    });
     expect(loadHistory(storage)).toEqual([]);
   });
 
   it("returns [] when the payload is not an array", () => {
-    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: JSON.stringify({ url: "x" }) });
+    const storage = createFakeStorage({
+      [GENERATION_HISTORY_KEY]: JSON.stringify({ url: "x" }),
+    });
     expect(loadHistory(storage)).toEqual([]);
   });
 
@@ -120,13 +151,18 @@ describe("loadHistory", () => {
   it("enforces the entry cap and markdown cap on load", () => {
     const many = Array.from({ length: MAX_HISTORY_ENTRIES + 5 }, (_, i) =>
       makeEntry(`https://github.com/o/r${i}`),
-    ).map((entry) => ({ ...entry, markdown: entry.markdown.repeat(MAX_MARKDOWN_CHARS) }));
+    ).map((entry) => ({
+      ...entry,
+      markdown: entry.markdown.repeat(MAX_MARKDOWN_CHARS),
+    }));
     const storage = createFakeStorage({
       [GENERATION_HISTORY_KEY]: JSON.stringify(many),
     });
     const loaded = loadHistory(storage);
     expect(loaded).toHaveLength(MAX_HISTORY_ENTRIES);
-    expect(loaded.every((entry) => entry.markdown.length <= MAX_MARKDOWN_CHARS)).toBe(true);
+    expect(
+      loaded.every((entry) => entry.markdown.length <= MAX_MARKDOWN_CHARS),
+    ).toBe(true);
   });
 });
 
@@ -157,7 +193,12 @@ describe("saveHistory", () => {
 
     let entries: GenerationHistoryEntry[] = [];
     for (let i = 0; i < 6; i++) {
-      entries = appendGeneration(entries, `https://github.com/owner/repo${i}`, "English", "# x");
+      entries = appendGeneration(
+        entries,
+        `https://github.com/owner/repo${i}`,
+        "English",
+        "# x",
+      );
     }
     expect(entries).toHaveLength(6);
 
@@ -180,7 +221,11 @@ describe("removeHistoryEntry", () => {
 
 describe("clearHistory", () => {
   it("removes the stored key", () => {
-    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: JSON.stringify([makeEntry("https://github.com/a/b")]) });
+    const storage = createFakeStorage({
+      [GENERATION_HISTORY_KEY]: JSON.stringify([
+        makeEntry("https://github.com/a/b"),
+      ]),
+    });
     clearHistory(storage);
     expect(storage.dump()).toEqual({});
   });

--- a/src/__tmp__/generationHistory.test.ts
+++ b/src/__tmp__/generationHistory.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  appendGeneration,
+  clearHistory,
+  GENERATION_HISTORY_KEY,
+  loadHistory,
+  MAX_HISTORY_ENTRIES,
+  MAX_MARKDOWN_CHARS,
+  removeHistoryEntry,
+  saveHistory,
+  type GenerationHistoryEntry,
+} from "@/lib/generationHistory";
+
+type FakeStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  dump: () => Record<string, string>;
+};
+
+function createFakeStorage(initial?: Record<string, string>): FakeStorage {
+  const store = new Map<string, string>(Object.entries(initial ?? {}));
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    dump: () => Object.fromEntries(store),
+  };
+}
+
+function makeEntry(url: string, language = "English", markdown = "# Readme"): GenerationHistoryEntry {
+  return {
+    id: `id-${url}-${language}`,
+    url,
+    language,
+    markdown,
+    createdAt: 1_000_000,
+  };
+}
+
+describe("appendGeneration", () => {
+  it("adds a new entry at the front and normalizes the URL", () => {
+    const next = appendGeneration([], "  https://github.com/Owner/Repo/ ", "English", "# Hi");
+    expect(next).toHaveLength(1);
+    expect(next[0].url).toBe("https://github.com/Owner/Repo");
+    expect(next[0].language).toBe("English");
+    expect(next[0].markdown).toBe("# Hi");
+  });
+
+  it("dedupes by URL + language, moving the existing entry to the front", () => {
+    const first = [makeEntry("https://github.com/a/b", "English")];
+    const oldDate = 100;
+    const firstWithDate = [{ ...first[0], createdAt: oldDate }];
+    const next = appendGeneration(firstWithDate, "https://github.com/A/B", "English", "# v2", 500);
+    expect(next).toHaveLength(1);
+    expect(next[0].markdown).toBe("# v2");
+    expect(next[0].createdAt).toBe(500);
+  });
+
+  it("keeps separate entries for different languages", () => {
+    const next = appendGeneration(
+      [makeEntry("https://github.com/a/b", "English")],
+      "https://github.com/a/b",
+      "Spanish",
+      "# v2",
+    );
+    expect(next).toHaveLength(2);
+  });
+
+  it("evicts the oldest entries beyond the maximum", () => {
+    let entries: GenerationHistoryEntry[] = [];
+    for (let i = 0; i < MAX_HISTORY_ENTRIES + 5; i++) {
+      entries = appendGeneration(entries, `https://github.com/owner/repo${i}`, "English", "# x");
+    }
+    expect(entries).toHaveLength(MAX_HISTORY_ENTRIES);
+    expect(entries[0].url).toBe(`https://github.com/owner/repo${MAX_HISTORY_ENTRIES + 4}`);
+  });
+
+  it("truncates oversized markdown", () => {
+    const hugeMarkdown = "x".repeat(MAX_MARKDOWN_CHARS + 500);
+    const next = appendGeneration([], "https://github.com/a/b", "English", hugeMarkdown);
+    expect(next[0].markdown.length).toBe(MAX_MARKDOWN_CHARS);
+  });
+});
+
+describe("loadHistory", () => {
+  it("returns [] when no key exists", () => {
+    expect(loadHistory(createFakeStorage())).toEqual([]);
+  });
+
+  it("returns [] for corrupt JSON", () => {
+    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: "{not json" });
+    expect(loadHistory(storage)).toEqual([]);
+  });
+
+  it("returns [] when the payload is not an array", () => {
+    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: JSON.stringify({ url: "x" }) });
+    expect(loadHistory(storage)).toEqual([]);
+  });
+
+  it("drops malformed entries and keeps valid ones", () => {
+    const payload = [
+      makeEntry("https://github.com/good/repo"),
+      { url: "https://github.com/broken/repo" },
+      "junk",
+      null,
+    ];
+    const storage = createFakeStorage({
+      [GENERATION_HISTORY_KEY]: JSON.stringify(payload),
+    });
+    const loaded = loadHistory(storage);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].url).toBe("https://github.com/good/repo");
+  });
+
+  it("enforces the entry cap and markdown cap on load", () => {
+    const many = Array.from({ length: MAX_HISTORY_ENTRIES + 5 }, (_, i) =>
+      makeEntry(`https://github.com/o/r${i}`),
+    ).map((entry) => ({ ...entry, markdown: entry.markdown.repeat(MAX_MARKDOWN_CHARS) }));
+    const storage = createFakeStorage({
+      [GENERATION_HISTORY_KEY]: JSON.stringify(many),
+    });
+    const loaded = loadHistory(storage);
+    expect(loaded).toHaveLength(MAX_HISTORY_ENTRIES);
+    expect(loaded.every((entry) => entry.markdown.length <= MAX_MARKDOWN_CHARS)).toBe(true);
+  });
+});
+
+describe("saveHistory", () => {
+  it("round-trips entries through localStorage", () => {
+    const storage = createFakeStorage();
+    const entries = [makeEntry("https://github.com/a/b", "English")];
+    saveHistory(entries, storage);
+    expect(loadHistory(storage)).toEqual(entries);
+  });
+
+  it("shrinks the payload when the quota is exceeded", () => {
+    const store = new Map<string, string>();
+    const storage: FakeStorage = {
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => {
+        const parsedLength = (JSON.parse(value) as unknown[]).length;
+        if (parsedLength >= 4) {
+          throw new Error("QuotaExceededError");
+        }
+        store.set(key, value);
+      },
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      dump: () => Object.fromEntries(store),
+    };
+
+    let entries: GenerationHistoryEntry[] = [];
+    for (let i = 0; i < 6; i++) {
+      entries = appendGeneration(entries, `https://github.com/owner/repo${i}`, "English", "# x");
+    }
+    expect(entries).toHaveLength(6);
+
+    expect(() => saveHistory(entries, storage)).not.toThrow();
+    expect(loadHistory(storage).length).toBeLessThan(6);
+  });
+});
+
+describe("removeHistoryEntry", () => {
+  it("removes the requested entry and keeps the rest", () => {
+    const entries = [
+      makeEntry("https://github.com/a/b", "English"),
+      makeEntry("https://github.com/c/d", "English"),
+    ];
+    const next = removeHistoryEntry(entries, entries[0].id);
+    expect(next).toHaveLength(1);
+    expect(next[0].url).toBe("https://github.com/c/d");
+  });
+});
+
+describe("clearHistory", () => {
+  it("removes the stored key", () => {
+    const storage = createFakeStorage({ [GENERATION_HISTORY_KEY]: JSON.stringify([makeEntry("https://github.com/a/b")]) });
+    clearHistory(storage);
+    expect(storage.dump()).toEqual({});
+  });
+});

--- a/src/__tmp__/generationHistory.test.ts
+++ b/src/__tmp__/generationHistory.test.ts
@@ -176,7 +176,9 @@ describe("saveHistory", () => {
   });
 
   it("returns null when no storage is available", () => {
-    expect(saveHistory([makeEntry("https://github.com/a/b", "English")], null)).toBeNull();
+    expect(
+      saveHistory([makeEntry("https://github.com/a/b", "English")], null),
+    ).toBeNull();
   });
 
   it("returns the persisted subset when the quota forces eviction", () => {

--- a/src/__tmp__/generationHistory.test.ts
+++ b/src/__tmp__/generationHistory.test.ts
@@ -170,11 +170,16 @@ describe("saveHistory", () => {
   it("round-trips entries through localStorage", () => {
     const storage = createFakeStorage();
     const entries = [makeEntry("https://github.com/a/b", "English")];
-    saveHistory(entries, storage);
+    const persisted = saveHistory(entries, storage);
+    expect(persisted).toEqual(entries);
     expect(loadHistory(storage)).toEqual(entries);
   });
 
-  it("shrinks the payload when the quota is exceeded", () => {
+  it("returns null when no storage is available", () => {
+    expect(saveHistory([makeEntry("https://github.com/a/b", "English")], null)).toBeNull();
+  });
+
+  it("returns the persisted subset when the quota forces eviction", () => {
     const store = new Map<string, string>();
     const storage: FakeStorage = {
       getItem: (key) => store.get(key) ?? null,
@@ -202,8 +207,10 @@ describe("saveHistory", () => {
     }
     expect(entries).toHaveLength(6);
 
-    expect(() => saveHistory(entries, storage)).not.toThrow();
-    expect(loadHistory(storage).length).toBeLessThan(6);
+    const persisted = saveHistory(entries, storage);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.length).toBeLessThan(6);
+    expect(persisted).toEqual(loadHistory(storage));
   });
 });
 

--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -119,7 +119,9 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
           data.markdown,
         );
         const persisted = saveHistory(nextHistory);
-        setHistory(persisted ?? nextHistory);
+        const committedHistory = persisted ?? nextHistory;
+        setHistory(committedHistory);
+        setActiveHistoryEntryId(committedHistory[0]?.id);
       } else {
         setMarkdown("");
         throw new Error(

--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -1,12 +1,21 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 import { SearchInput } from "@/components/Generator/SearchInput";
 import { MarkdownPreview } from "@/components/Generator/MarkdownPreview";
+import { GenerationHistory } from "@/components/Generator/GenerationHistory";
 import LoadingOverlay from "@/components/Generator/LoadingOverlay";
 import { navLinks } from "@/constants/navLinks";
 import { TerminalMockup } from "@/components/sections/TerminalMockup";
+import {
+  appendGeneration,
+  clearHistory,
+  loadHistory,
+  saveHistory,
+  GENERATION_HISTORY_KEY,
+  type GenerationHistoryEntry,
+} from "@/lib/generationHistory";
 
 interface GeneratePageProps {
   repoSlug?: string;
@@ -20,6 +29,13 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
   const [authRequired, setAuthRequired] = useState(false);
   const [privateRepoConsentRequired, setPrivateRepoConsentRequired] =
     useState(false);
+  const [history, setHistory] = useState<GenerationHistoryEntry[]>([]);
+  const [restoredForm, setRestoredForm] = useState<{
+    url: string;
+    language: string;
+  } | null>(null);
+  const [restoreKey, setRestoreKey] = useState(0);
+  const previewRef = useRef<HTMLDivElement>(null);
 
   // Optional: Update document title for SPA navigation
   useEffect(() => {
@@ -30,6 +46,18 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
       document.title = "ReadmeGenAI – AI GitHub README Generator";
     }
   }, [repoSlug]);
+
+  useEffect(() => {
+    setHistory(loadHistory());
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === GENERATION_HISTORY_KEY) {
+        setHistory(loadHistory());
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   const handleGenerate = async (
     githubUrl: string,
@@ -83,6 +111,16 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
       const data = await response.json();
       if (data && typeof data.markdown === "string") {
         setMarkdown(data.markdown);
+        setHistory((prev) => {
+          const next = appendGeneration(
+            prev,
+            githubUrl,
+            language,
+            data.markdown,
+          );
+          saveHistory(next);
+          return next;
+        });
       } else {
         setMarkdown("");
         throw new Error(
@@ -106,6 +144,25 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
     setAuthRequired(false);
   };
 
+  const handleRestoreGeneration = (entry: GenerationHistoryEntry) => {
+    setRestoredForm({ url: entry.url, language: entry.language });
+    setRestoreKey((key) => key + 1);
+    setMarkdown(entry.markdown);
+    setErrorMessage(null);
+    setErrorCode(null);
+    setAuthRequired(false);
+    setPrivateRepoConsentRequired(false);
+    previewRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  };
+
+  const handleClearHistory = () => {
+    setHistory([]);
+    clearHistory();
+  };
+
   return (
     <div className="relative min-h-screen bg-black text-white">
       {/* UI LOADING OVERLAY 
@@ -120,9 +177,14 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
           Generate Your AI-Powered README
         </h1>
         <SearchInput
+          key={`${restoreKey}|${restoredForm?.url ?? ""}|${restoredForm?.language ?? ""}`}
           onGenerate={handleGenerate}
           isLoading={isLoading}
-          initialValue={repoSlug ? `https://github.com/${repoSlug}` : ""}
+          initialValue={
+            restoredForm?.url ??
+            (repoSlug ? `https://github.com/${repoSlug}` : "")
+          }
+          initialLanguage={restoredForm?.language ?? "English"}
           ariaLabel="Enter GitHub repository URL to generate README"
           serverError={errorMessage}
           authRequired={authRequired}
@@ -130,7 +192,17 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
           privateRepoConsentRequired={privateRepoConsentRequired}
           onClearPrivateRepoConsent={clearGenerateFormState}
         />
-        <MarkdownPreview content={markdown} />
+        <div className="mt-4">
+          <GenerationHistory
+            entries={history}
+            activeUrl={restoredForm?.url}
+            onRestore={handleRestoreGeneration}
+            onClearAll={handleClearHistory}
+          />
+        </div>
+        <div ref={previewRef} className="scroll-mt-24">
+          <MarkdownPreview content={markdown} />
+        </div>
       </main>
       <TerminalMockup />
       <Footer />

--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -30,6 +30,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
   const [privateRepoConsentRequired, setPrivateRepoConsentRequired] =
     useState(false);
   const [history, setHistory] = useState<GenerationHistoryEntry[]>([]);
+  const [activeHistoryEntryId, setActiveHistoryEntryId] = useState<string>();
   const [restoredForm, setRestoredForm] = useState<{
     url: string;
     language: string;
@@ -111,16 +112,14 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
       const data = await response.json();
       if (data && typeof data.markdown === "string") {
         setMarkdown(data.markdown);
-        setHistory((prev) => {
-          const next = appendGeneration(
-            prev,
-            githubUrl,
-            language,
-            data.markdown,
-          );
-          saveHistory(next);
-          return next;
-        });
+        const nextHistory = appendGeneration(
+          history,
+          githubUrl,
+          language,
+          data.markdown,
+        );
+        const persisted = saveHistory(nextHistory);
+        setHistory(persisted ?? nextHistory);
       } else {
         setMarkdown("");
         throw new Error(
@@ -146,6 +145,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
 
   const handleRestoreGeneration = (entry: GenerationHistoryEntry) => {
     setRestoredForm({ url: entry.url, language: entry.language });
+    setActiveHistoryEntryId(entry.id);
     setRestoreKey((key) => key + 1);
     setMarkdown(entry.markdown);
     setErrorMessage(null);
@@ -195,7 +195,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
         <div className="mt-4">
           <GenerationHistory
             entries={history}
-            activeUrl={restoredForm?.url}
+            activeEntryId={activeHistoryEntryId}
             onRestore={handleRestoreGeneration}
             onClearAll={handleClearHistory}
           />

--- a/src/components/Generator/GenerationHistory.tsx
+++ b/src/components/Generator/GenerationHistory.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import React, { useState } from "react";
+import { ChevronDown, Clock, History, RotateCcw, Trash2 } from "lucide-react";
+import type { GenerationHistoryEntry } from "@/lib/generationHistory";
+import { normalizeRepoUrl } from "@/lib/generationHistory";
+
+interface GenerationHistoryProps {
+  entries: GenerationHistoryEntry[];
+  activeUrl?: string;
+  onRestore: (entry: GenerationHistoryEntry) => void;
+  onClearAll: () => void;
+}
+
+function formatRelativeTime(timestamp: number): string {
+  const diffSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - timestamp) / 1000),
+  );
+  if (diffSeconds < 60) return "just now";
+
+  const minutes = Math.floor(diffSeconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export const GenerationHistory = ({
+  entries,
+  activeUrl,
+  onRestore,
+  onClearAll,
+}: GenerationHistoryProps) => {
+  const [open, setOpen] = useState(true);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  if (entries.length === 0) return null;
+
+  const handleClear = () => {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      return;
+    }
+    setConfirmClear(false);
+    onClearAll();
+  };
+
+  const activeUrlForCompare = activeUrl ? urlForCompare(activeUrl) : "";
+
+  return (
+    <div className="w-full rounded-2xl border border-white/10 bg-zinc-900/40 backdrop-blur-xl overflow-hidden">
+      <div className="flex items-center justify-between gap-4 px-4 py-3">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          className="flex items-center gap-2 text-sm font-medium text-zinc-300 transition-colors hover:text-white"
+        >
+          <History size={16} className="text-blue-400" />
+          Recent generations
+          <span className="text-xs text-zinc-500">({entries.length})</span>
+          <ChevronDown
+            size={14}
+            className={`transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {confirmClear ? (
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-zinc-400">Clear all?</span>
+            <button
+              type="button"
+              onClick={handleClear}
+              className="font-semibold text-red-400 transition-colors hover:text-red-300"
+            >
+              Yes
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmClear(false)}
+              className="text-zinc-400 transition-colors hover:text-white"
+            >
+              No
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="flex items-center gap-1.5 text-xs text-zinc-500 transition-colors hover:text-red-400"
+          >
+            <Trash2 size={14} />
+            Clear history
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <ul className="divide-y divide-white/5 border-t border-white/10">
+          {entries.map((entry) => {
+            const isActive = urlForCompare(entry.url) === activeUrlForCompare;
+            return (
+              <li key={entry.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    onRestore(entry);
+                  }}
+                  className={`flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5 ${
+                    isActive ? "bg-blue-500/10" : ""
+                  }`}
+                >
+                  <RotateCcw
+                    size={14}
+                    className="shrink-0 text-zinc-500"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-mono text-xs text-zinc-200">
+                      {entry.url}
+                    </span>
+                    <span className="mt-0.5 flex items-center gap-1.5 text-[11px] text-zinc-500">
+                      <Clock size={11} />
+                      {formatRelativeTime(entry.createdAt)}
+                      <span className="sr-only">generated</span>
+                    </span>
+                  </span>
+                  <span className="shrink-0 rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-zinc-400">
+                    {entry.language}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <p className="border-t border-white/10 px-4 py-2 text-[10px] text-zinc-600">
+        Saved only in this browser on this device.
+      </p>
+    </div>
+  );
+};
+
+function urlForCompare(url: string): string {
+  return normalizeRepoUrl(url).toLowerCase();
+}
+
+export default GenerationHistory;

--- a/src/components/Generator/GenerationHistory.tsx
+++ b/src/components/Generator/GenerationHistory.tsx
@@ -13,10 +13,7 @@ interface GenerationHistoryProps {
 }
 
 function formatRelativeTime(timestamp: number): string {
-  const diffSeconds = Math.max(
-    0,
-    Math.floor((Date.now() - timestamp) / 1000),
-  );
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
   if (diffSeconds < 60) return "just now";
 
   const minutes = Math.floor(diffSeconds / 60);
@@ -115,10 +112,7 @@ export const GenerationHistory = ({
                     isActive ? "bg-blue-500/10" : ""
                   }`}
                 >
-                  <RotateCcw
-                    size={14}
-                    className="shrink-0 text-zinc-500"
-                  />
+                  <RotateCcw size={14} className="shrink-0 text-zinc-500" />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate font-mono text-xs text-zinc-200">
                       {entry.url}

--- a/src/components/Generator/GenerationHistory.tsx
+++ b/src/components/Generator/GenerationHistory.tsx
@@ -3,11 +3,10 @@
 import React, { useState } from "react";
 import { ChevronDown, Clock, History, RotateCcw, Trash2 } from "lucide-react";
 import type { GenerationHistoryEntry } from "@/lib/generationHistory";
-import { normalizeRepoUrl } from "@/lib/generationHistory";
 
 interface GenerationHistoryProps {
   entries: GenerationHistoryEntry[];
-  activeUrl?: string;
+  activeEntryId?: string;
   onRestore: (entry: GenerationHistoryEntry) => void;
   onClearAll: () => void;
 }
@@ -28,7 +27,7 @@ function formatRelativeTime(timestamp: number): string {
 
 export const GenerationHistory = ({
   entries,
-  activeUrl,
+  activeEntryId,
   onRestore,
   onClearAll,
 }: GenerationHistoryProps) => {
@@ -45,8 +44,6 @@ export const GenerationHistory = ({
     setConfirmClear(false);
     onClearAll();
   };
-
-  const activeUrlForCompare = activeUrl ? urlForCompare(activeUrl) : "";
 
   return (
     <div className="w-full rounded-2xl border border-white/10 bg-zinc-900/40 backdrop-blur-xl overflow-hidden">
@@ -99,7 +96,7 @@ export const GenerationHistory = ({
       {open && (
         <ul className="divide-y divide-white/5 border-t border-white/10">
           {entries.map((entry) => {
-            const isActive = urlForCompare(entry.url) === activeUrlForCompare;
+            const isActive = entry.id === activeEntryId;
             return (
               <li key={entry.id}>
                 <button
@@ -139,9 +136,5 @@ export const GenerationHistory = ({
     </div>
   );
 };
-
-function urlForCompare(url: string): string {
-  return normalizeRepoUrl(url).toLowerCase();
-}
 
 export default GenerationHistory;

--- a/src/components/Generator/SearchInput.tsx
+++ b/src/components/Generator/SearchInput.tsx
@@ -9,6 +9,7 @@ interface SearchInputProps {
   onClearPrivateRepoConsent: () => void;
   isLoading: boolean;
   initialValue?: string; // optional initial value
+  initialLanguage?: string; // optional initial language
   ariaLabel?: string; // optional aria-label for accessibility
   serverError?: string | null;
   authRequired?: boolean;
@@ -28,6 +29,7 @@ export const SearchInput = ({
   onClearPrivateRepoConsent,
   isLoading,
   initialValue,
+  initialLanguage,
   ariaLabel,
   serverError,
   authRequired = false,
@@ -36,7 +38,7 @@ export const SearchInput = ({
 }: SearchInputProps) => {
   // Initialize state directly from initialValue once
   const [url, setUrl] = useState(initialValue || "");
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState(initialLanguage || "English");
   const [error, setError] = useState<string | null>(null);
   const [ackPrivateRepo, setAckPrivateRepo] = useState(false);
 

--- a/src/lib/generationHistory.ts
+++ b/src/lib/generationHistory.ts
@@ -1,0 +1,139 @@
+export const GENERATION_HISTORY_KEY = "readmegenai.generationHistory";
+
+export const MAX_HISTORY_ENTRIES = 10;
+
+export const MAX_MARKDOWN_CHARS = 120_000;
+
+export interface GenerationHistoryEntry {
+  id: string;
+  url: string;
+  language: string;
+  markdown: string;
+  createdAt: number;
+}
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function getStorage(): StorageLike | null {
+  if (typeof globalThis === "undefined") return null;
+  const storage = (globalThis as { localStorage?: StorageLike }).localStorage;
+  return storage ?? null;
+}
+
+function createId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function normalizeRepoUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function urlForCompare(url: string): string {
+  return normalizeRepoUrl(url).toLowerCase();
+}
+
+function isEntry(value: unknown): value is GenerationHistoryEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.url === "string" &&
+    typeof record.language === "string" &&
+    typeof record.markdown === "string" &&
+    typeof record.createdAt === "number"
+  );
+}
+
+function sanitizeEntries(values: unknown): GenerationHistoryEntry[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .filter(isEntry)
+    .map((entry) => ({
+      ...entry,
+      markdown: entry.markdown.slice(0, MAX_MARKDOWN_CHARS),
+    }))
+    .slice(0, MAX_HISTORY_ENTRIES);
+}
+
+export function loadHistory(
+  storage: StorageLike | null = getStorage(),
+): GenerationHistoryEntry[] {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(GENERATION_HISTORY_KEY);
+    if (!raw) return [];
+    return sanitizeEntries(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+export function appendGeneration(
+  current: GenerationHistoryEntry[],
+  url: string,
+  language: string,
+  markdown: string,
+  now: number = Date.now(),
+): GenerationHistoryEntry[] {
+  const normalizedUrl = normalizeRepoUrl(url);
+  const normalizedLanguage = language.trim() || "English";
+  const existingIndex = current.findIndex(
+    (entry) =>
+      urlForCompare(entry.url) === urlForCompare(normalizedUrl) &&
+      entry.language === normalizedLanguage,
+  );
+
+  const next: GenerationHistoryEntry[] = [
+    {
+      id: createId(),
+      url: normalizedUrl,
+      language: normalizedLanguage,
+      markdown: markdown.slice(0, MAX_MARKDOWN_CHARS),
+      createdAt: now,
+    },
+    ...current.filter((_, index) => index !== existingIndex),
+  ];
+
+  return next.slice(0, MAX_HISTORY_ENTRIES);
+}
+
+export function removeHistoryEntry(
+  current: GenerationHistoryEntry[],
+  id: string,
+): GenerationHistoryEntry[] {
+  return current.filter((entry) => entry.id !== id);
+}
+
+export function saveHistory(
+  entries: GenerationHistoryEntry[],
+  storage: StorageLike | null = getStorage(),
+): void {
+  if (!storage) return;
+  let pool = entries;
+  for (;;) {
+    try {
+      storage.setItem(GENERATION_HISTORY_KEY, JSON.stringify(pool));
+      return;
+    } catch {
+      if (pool.length <= 1) return;
+      pool = pool.slice(0, Math.ceil(pool.length / 2));
+    }
+  }
+}
+
+export function clearHistory(
+  storage: StorageLike | null = getStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(GENERATION_HISTORY_KEY);
+  } catch {
+    // Ignore storage errors; in-memory state is cleared by the caller.
+  }
+}

--- a/src/lib/generationHistory.ts
+++ b/src/lib/generationHistory.ts
@@ -16,8 +16,11 @@ type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 function getStorage(): StorageLike | null {
   if (typeof globalThis === "undefined") return null;
-  const storage = (globalThis as { localStorage?: StorageLike }).localStorage;
-  return storage ?? null;
+  try {
+    return (globalThis as { localStorage?: StorageLike }).localStorage ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function createId(): string {
@@ -113,15 +116,15 @@ export function removeHistoryEntry(
 export function saveHistory(
   entries: GenerationHistoryEntry[],
   storage: StorageLike | null = getStorage(),
-): void {
-  if (!storage) return;
+): GenerationHistoryEntry[] | null {
+  if (!storage) return null;
   let pool = entries;
   for (;;) {
     try {
       storage.setItem(GENERATION_HISTORY_KEY, JSON.stringify(pool));
-      return;
+      return pool;
     } catch {
-      if (pool.length <= 1) return;
+      if (pool.length <= 1) return null;
       pool = pool.slice(0, Math.ceil(pool.length / 2));
     }
   }

--- a/src/lib/generationHistory.ts
+++ b/src/lib/generationHistory.ts
@@ -127,9 +127,7 @@ export function saveHistory(
   }
 }
 
-export function clearHistory(
-  storage: StorageLike | null = getStorage(),
-): void {
+export function clearHistory(storage: StorageLike | null = getStorage()): void {
   if (!storage) return;
   try {
     storage.removeItem(GENERATION_HISTORY_KEY);


### PR DESCRIPTION
Closes #162

Persists recent generated repositories in the browser (localStorage) and adds a history panel to the generate page.

### Changes
- New \src/lib/generationHistory.ts\ — SSR-safe storage layer with max 10 entries, markdown cap (~120KB), URL+language dedupe, oldest-eviction, quota-exceeded retry, and corrupt-data tolerance.
- New \src/components/Generator/GenerationHistory.tsx\ — collapsible panel showing recent generations with relative timestamps and language badges; clicking an item restores the saved output and pre-fills the form; clear-all with inline confirm; note that data stays on-device.
- \GeneratePageClient.tsx\ — history state, cross-tab sync via the \storage\ event, persistence on successful generation, restore and clear handlers.
- \SearchInput.tsx\ — optional \initialLanguage\ prop so a restored entry pre-fills both URL and language.
- Unit tests: \src/__tmp__/generationHistory.test.ts\ (append/dedupe/eviction/truncation, corrupt-data tolerance, quota fallback, round-trip, remove/clear).

### Acceptances
- Recent generations survive refresh (localStorage-backed). ✔
- Last few repos reopen via the panel (restores output + form, no regeneration). ✔
- History can be cleared from the UI. ✔

### Validation
- \
px vitest run\ — 17/17 passing
- \
pm run lint\, \
px tsc --noEmit\, \
pm run build\ — clean