### PR TITLE
feat: allow deleting individual generation history entries

### DIFF
--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -14,6 +14,7 @@ import {
   loadHistory,
   removeHistoryEntry,
   saveHistory,
+  saveHistoryWithoutEviction,
   GENERATION_HISTORY_KEY,
   type GenerationHistoryEntry,
 } from "@/lib/generationHistory";
@@ -168,8 +169,9 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
 
   const handleDeleteHistoryEntry = (entryId: string) => {
     const nextHistory = removeHistoryEntry(history, entryId);
-    const persisted = saveHistory(nextHistory);
-    setHistory(persisted ?? nextHistory);
+    if (!saveHistoryWithoutEviction(nextHistory)) return;
+
+    setHistory(nextHistory);
 
     if (activeHistoryEntryId === entryId) {
       setActiveHistoryEntryId(undefined);

--- a/src/app/generate/GeneratePageClient.tsx
+++ b/src/app/generate/GeneratePageClient.tsx
@@ -12,6 +12,7 @@ import {
   appendGeneration,
   clearHistory,
   loadHistory,
+  removeHistoryEntry,
   saveHistory,
   GENERATION_HISTORY_KEY,
   type GenerationHistoryEntry,
@@ -165,6 +166,16 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
     clearHistory();
   };
 
+  const handleDeleteHistoryEntry = (entryId: string) => {
+    const nextHistory = removeHistoryEntry(history, entryId);
+    const persisted = saveHistory(nextHistory);
+    setHistory(persisted ?? nextHistory);
+
+    if (activeHistoryEntryId === entryId) {
+      setActiveHistoryEntryId(undefined);
+    }
+  };
+
   return (
     <div className="relative min-h-screen bg-black text-white">
       {/* UI LOADING OVERLAY 
@@ -199,6 +210,7 @@ export default function GeneratePageClient({ repoSlug }: GeneratePageProps) {
             entries={history}
             activeEntryId={activeHistoryEntryId}
             onRestore={handleRestoreGeneration}
+            onDelete={handleDeleteHistoryEntry}
             onClearAll={handleClearHistory}
           />
         </div>

--- a/src/components/Generator/GenerationHistory.tsx
+++ b/src/components/Generator/GenerationHistory.tsx
@@ -8,6 +8,7 @@ interface GenerationHistoryProps {
   entries: GenerationHistoryEntry[];
   activeEntryId?: string;
   onRestore: (entry: GenerationHistoryEntry) => void;
+  onDelete: (entryId: string) => void;
   onClearAll: () => void;
 }
 
@@ -29,6 +30,7 @@ export const GenerationHistory = ({
   entries,
   activeEntryId,
   onRestore,
+  onDelete,
   onClearAll,
 }: GenerationHistoryProps) => {
   const [open, setOpen] = useState(true);
@@ -98,14 +100,14 @@ export const GenerationHistory = ({
           {entries.map((entry) => {
             const isActive = entry.id === activeEntryId;
             return (
-              <li key={entry.id}>
+              <li key={entry.id} className="group flex items-center">
                 <button
                   type="button"
                   onClick={() => {
                     setOpen(false);
                     onRestore(entry);
                   }}
-                  className={`flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5 ${
+                  className={`flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5 ${
                     isActive ? "bg-blue-500/10" : ""
                   }`}
                 >
@@ -123,6 +125,15 @@ export const GenerationHistory = ({
                   <span className="shrink-0 rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-zinc-400">
                     {entry.language}
                   </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(entry.id)}
+                  aria-label={`Delete generation for ${entry.url}`}
+                  title="Delete generation"
+                  className="mr-4 shrink-0 rounded p-1.5 text-zinc-600 opacity-0 transition-colors hover:bg-red-500/10 hover:text-red-400 focus:opacity-100 group-hover:opacity-100"
+                >
+                  <Trash2 size={14} />
                 </button>
               </li>
             );

--- a/src/lib/generationHistory.ts
+++ b/src/lib/generationHistory.ts
@@ -130,6 +130,19 @@ export function saveHistory(
   }
 }
 
+export function saveHistoryWithoutEviction(
+  entries: GenerationHistoryEntry[],
+  storage: StorageLike | null = getStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(GENERATION_HISTORY_KEY, JSON.stringify(entries));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function clearHistory(storage: StorageLike | null = getStorage()): void {
   if (!storage) return;
   try {


### PR DESCRIPTION
## 🚀 BΞYTΞFLʘW | Pull Request Protocol

**PR Type:** `feat`
**Issue Link:** Fixes #225

---

### 📝 System Summary

Adds an individual delete control to each recent-generation entry, so users can remove outdated history items without clearing all saved generations.

### 🛠️ Technical Changes

- [x] Logic change in `src/app/generate/GeneratePageClient.tsx` to remove an entry from persisted and in-memory history, and clear the active entry when applicable.
- [x] UI update in `src/components/Generator/GenerationHistory.tsx` to add a hover-visible per-entry trash control.
- [ ] Database schema updated: not applicable.

### 🧪 Quality Assurance (QA)

- [x] **Linting:** `npm run lint` completed successfully.
- [ ] **Build:** Not run.
- [x] **Testing:** TypeScript validation passed; local functionality was manually tested.
- [x] **Dark Mode:** Delete control follows the existing high-contrast dark UI styling.

### 🖼️ Visual Evidence

Add a screenshot showing the history panel and its per-entry delete control here.

---

### 📡 Developer Authorization

- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings in the console.
- [ ] I have updated the documentation (if applicable).

**Authorized by:** @anshk1234  
**Timestamp:** 5 September 2026, IST